### PR TITLE
修复回放url拦截问题

### DIFF
--- a/iOS/DiDiPrism/Src/Ability/BehaviorReplay/Intercept/PrismReplayNSURLProtocol.m
+++ b/iOS/DiDiPrism/Src/Ability/BehaviorReplay/Intercept/PrismReplayNSURLProtocol.m
@@ -54,9 +54,9 @@
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+    NSMutableURLRequest *mutableReqeust = request.mutableCopy;
     __block NSString *mockUrl = nil;
     __block NSDictionary *mockResult = nil;
-    NSString *httpMethod = request.HTTPMethod;
     NSArray<PrismBehaviorItemRequestInfoModel*> *requestInfos = [NSURLProtocol propertyForKey:PRISM_REQUEST_INFOS inRequest:request];
     NSString *urlFlag = [PrismBehaviorReplayManager sharedManager].urlFlagPickBlock ? [PrismBehaviorReplayManager sharedManager].urlFlagPickBlock(request) : nil;
     [requestInfos enumerateObjectsUsingBlock:^(PrismBehaviorItemRequestInfoModel * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -72,14 +72,11 @@
             }
             else {
                 // 方式一
-                mockUrl = obj.mockUrl;
+                mutableReqeust.URL = [NSURL URLWithString:obj.mockUrl];
             }
             *stop = YES;
         }
     }];
-    
-    NSMutableURLRequest *mutableReqeust = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:mockUrl]];
-    mutableReqeust.HTTPMethod = httpMethod;
     [NSURLProtocol setProperty:@(YES) forKey:PRISM_REQUEST_HAS_INIT inRequest:mutableReqeust];
     [NSURLProtocol setProperty:mockResult forKey:PRISM_REQUEST_MOCK_RESULT inRequest:mutableReqeust];
     request = [mutableReqeust copy];

--- a/iOS/DiDiPrism/Src/Ability/BehaviorReplay/Intercept/PrismReplayNSURLProtocol.m
+++ b/iOS/DiDiPrism/Src/Ability/BehaviorReplay/Intercept/PrismReplayNSURLProtocol.m
@@ -58,7 +58,7 @@
     __block NSDictionary *mockResult = nil;
     NSString *httpMethod = request.HTTPMethod;
     NSArray<PrismBehaviorItemRequestInfoModel*> *requestInfos = [NSURLProtocol propertyForKey:PRISM_REQUEST_INFOS inRequest:request];
-    NSString *urlFlag = [NSString stringWithFormat:@"%@", request.URL.path];
+    NSString *urlFlag = [PrismBehaviorReplayManager sharedManager].urlFlagPickBlock ? [PrismBehaviorReplayManager sharedManager].urlFlagPickBlock(request) : nil;
     [requestInfos enumerateObjectsUsingBlock:^(PrismBehaviorItemRequestInfoModel * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         if ([obj.originUrl containsString:urlFlag]) {
             /*


### PR DESCRIPTION
修改回放拦截url的两个问题：
1、回放url拦截 flag判断条件不对
2、request重新创建可能缺少信息并且可能为nil（通过result mock的时候）